### PR TITLE
added close parenthesis in getDefaultTracker method

### DIFF
--- a/iphone/Classes/ComAnimecycAnalyticsModule.m
+++ b/iphone/Classes/ComAnimecycAnalyticsModule.m
@@ -95,7 +95,7 @@ static BOOL debugging = NO;
 
 - (id)getDefaultTracker:(id)args
 {
-    [ComAnimecycAnalyticsModule debugWithMessage:@"Getting default tracker.";
+    [ComAnimecycAnalyticsModule debugWithMessage:@"Getting default tracker."];
 
     return [[[ComAnimecycAnalyticsTrackerProxy alloc] initWithDefault] autorelease];
 }


### PR DESCRIPTION
Unable to build this module because there is a close parenthesis missed in getDefaultTracker method. In this pull request I have fixed this issue. 
